### PR TITLE
Added support for menu items

### DIFF
--- a/public/js/wp-post-modal-public.js
+++ b/public/js/wp-post-modal-public.js
@@ -65,7 +65,7 @@
 
                     // Define variables
                     var modalContent = $('#modal-content');
-                    var $this = $(this);
+                    var $this = ($(this).attr('href') != null) ? $(this) : $(this).children("a").first();
                     var postLink = $this.attr('href');
                     var dataDivID = ' #' + $this.attr('data-div');
                     var $pluginUrl = $('#modal-ready').attr('data-plugin-path');


### PR DESCRIPTION
There was an issue that prevented me from triggering modals from menu items because the `.modal-link` class was being applied to the `<li>` instead of the `<a>`. This addresses that.