### PR TITLE
Update wp-post-modal-public.css

### DIFF
--- a/public/css/wp-post-modal-public.css
+++ b/public/css/wp-post-modal-public.css
@@ -1,6 +1,5 @@
 /** default styles **/
 body.no-scroll {
-    position: fixed;
     overflow: hidden;
     width: 100%;
 }


### PR DESCRIPTION
Don't scroll top when modal opens